### PR TITLE
test: remove duplicate confidence assertion

### DIFF
--- a/src/lib/services/__tests__/interactiveAnalyzer.test.ts
+++ b/src/lib/services/__tests__/interactiveAnalyzer.test.ts
@@ -56,10 +56,9 @@ describe('InteractiveAnalyzer', () => {
 			// Basic analysis should work
 			expect(result.domain).toBeDefined();
 			expect(result.contentType).toBe('general');
-			expect(result.confidence).toBeGreaterThan(0);
-			expect(result.confidence).toBeGreaterThan(0);
-			expect(result.qualityMetrics).toBeDefined();
-			expect(result.opportunities).toBeDefined();
+                        expect(result.confidence).toBeGreaterThan(0);
+                        expect(result.qualityMetrics).toBeDefined();
+                        expect(result.opportunities).toBeDefined();
 		});
 
 		it('should detect interactive code blocks', () => {


### PR DESCRIPTION
## Summary
- remove duplicate confidence check in InteractiveAnalyzer analyzeContent test

## Testing
- `npm test -- run` (fails: expected undefined to be defined)


------
https://chatgpt.com/codex/tasks/task_e_689a329c34ec8326a0b0f99de31fae53

## Summary by Sourcery

Tests:
- Remove duplicate confidence assertion from the InteractiveAnalyzer analyzeContent test