### PR TITLE
fix categorizeContent argument order

### DIFF
--- a/src/lib/services/webContentFetcher.ts
+++ b/src/lib/services/webContentFetcher.ts
@@ -243,7 +243,8 @@ export class WebContentFetcher {
             keywords,
             attribution: originalUrl,
             tags: [], // Will be populated by content analysis
-            category: this.categorizeContent(content_type, domain, description, description)
+            // category is determined by contentType, domain, title, then description
+            category: this.categorizeContent(content_type, domain, title, description)
         };
     }
 


### PR DESCRIPTION
## Summary
- pass metadata title instead of description to categorizeContent
- document categorizeContent parameter order in extractMetadata

## Testing
- `npm test` *(fails: web-content fetching & interactive components tests)*
- `npm run lint` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_689a329e5ff48326afc10fd31dc54252

## Summary by Sourcery

Reorder categorizeContent arguments to correctly use title and update inline documentation to clarify parameter order

Bug Fixes:
- Fix argument order in categorizeContent call to pass title instead of description

Enhancements:
- Add inline documentation for categorizeContent parameter order