### PR TITLE
test: verify interactive code block detection

### DIFF
--- a/src/lib/services/__tests__/interactiveAnalyzer.test.ts
+++ b/src/lib/services/__tests__/interactiveAnalyzer.test.ts
@@ -108,13 +108,13 @@ describe('InteractiveAnalyzer', () => {
 
 			const result = analyzer.analyzeContent(web_content);
 
-			expect(result.domain).toBeDefined();
-			expect(result.interactiveElements.length).toBeGreaterThanOrEqual(0);
-			if (result.interactiveElements.length > 0) {
-				expect(result.interactiveElements[0].type).toBe('code');
-			}
-			expect(result.opportunities.length).toBeGreaterThanOrEqual(0);
-		});
+                        expect(result.domain).toBeDefined();
+                        expect(result.interactiveElements.length).toBe(1);
+                        expect(result.interactiveElements[0].type).toBe('code');
+                        // Ensure the detected element is executable/interactable
+                        expect(result.interactiveElements[0].executable).toBe(true);
+                        expect(result.opportunities.length).toBeGreaterThanOrEqual(0);
+                });
 
 		it('should detect table opportunities', () => {
 			const web_content = {


### PR DESCRIPTION
## Summary
- enforce single interactive code block detection
- assert type 'code' and executable flag

## Testing
- `pnpm test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_689a826d0e988326b74761c64013cb01

## Summary by Sourcery

Enforce single interactive code block detection and validate its type and executable flag in tests

Tests:
- Update interactiveAnalyzer tests to expect exactly one interactive element
- Add assertion for interactive element type to be 'code'
- Add assertion for interactive element executable flag to be true