### PR TITLE
feat: export logger type

### DIFF
--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -4,41 +4,41 @@
  * In production, only info, warn, and error logs are shown
  */
 const is_development =
-	// @ts-ignore - import.meta.env is defined by Vite
-	(import.meta.env?.MODE && import.meta.env.MODE !== 'production') ||
-	// Fallback for Node.js environment
-	(typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production');
-
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
-
+  // @ts-ignore - import.meta.env is defined by Vite
+  (import.meta.env?.MODE && import.meta.env.MODE !== "production") ||
+  // Fallback for Node.js environment
+  (typeof process !== "undefined" && process.env?.NODE_ENV !== "production");
 /**
  * Creates a logger instance with a given name
  * @param name Name to prefix log messages with
  */
 export function createLogger(name: string) {
-	const prefix = `[${name}]`;
+  const prefix = `[${name}]`;
 
-	return {
-		debug: (...args: unknown[]) => {
-			if (is_development) {
-				// eslint-disable-next-line no-console
-				console.debug(prefix, ...args);
-			}
-		},
-		info: (...args: unknown[]) => {
-			// eslint-disable-next-line no-console
-			console.info(prefix, ...args);
-		},
-		warn: (...args: unknown[]) => {
-			// eslint-disable-next-line no-console
-			console.warn(prefix, ...args);
-		},
-		error: (...args: unknown[]) => {
-			// eslint-disable-next-line no-console
-			console.error(prefix, ...args);
-		}
-	};
+  return {
+    debug: (...args: unknown[]) => {
+      if (is_development) {
+        // eslint-disable-next-line no-console
+        console.debug(prefix, ...args);
+      }
+    },
+    info: (...args: unknown[]) => {
+      // eslint-disable-next-line no-console
+      console.info(prefix, ...args);
+    },
+    warn: (...args: unknown[]) => {
+      // eslint-disable-next-line no-console
+      console.warn(prefix, ...args);
+    },
+    error: (...args: unknown[]) => {
+      // eslint-disable-next-line no-console
+      console.error(prefix, ...args);
+    },
+  };
 }
 
 // Default logger instance
-export const logger = createLogger('app');
+export const logger = createLogger("app");
+
+// Re-export the logger type for modules that need it
+export type Logger = ReturnType<typeof createLogger>;


### PR DESCRIPTION
## Summary
- export Logger type from logger utility

## Testing
- `npm test` (fails: lifecycle_function_unavailable, crypto.randomUUID not a function)
- `npx prettier --check src/lib/utils/logger.ts`
- `npx eslint src/lib/utils/logger.ts` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a85972ad4832684152743e0ae3091

## Summary by Sourcery

New Features:
- Export Logger type alias from the createLogger utility for external use